### PR TITLE
Fix bug with hardcoded device ID

### DIFF
--- a/src/smartThingsPlatform.ts
+++ b/src/smartThingsPlatform.ts
@@ -150,7 +150,7 @@ export class SmartThingsPlatform implements DynamicPlatformPlugin {
       displayName = deviceMapping.nameOverride;
     }
 
-    const accessory = new this.api.platformAccessory(displayName, '6781aefe-0185-4e86-8265-84c52a94b8a0');
+    const accessory = new this.api.platformAccessory(displayName, device.deviceId);
     accessory.context.device = device;
     accessory.category = this.api.hap.Categories.TELEVISION;
     this.api.publishExternalAccessories(PLUGIN_NAME, [accessory]);


### PR DESCRIPTION
This error was causing my Homebridge server to crash loop on v2.1.0:

```
[6/30/2024, 5:46:04 PM] Error: Accessory Living Room TV experienced an address collision.
    at BridgeService.handlePublishExternalAccessories (/var/lib/homebridge/node_modules/homebridge/src/bridgeService.ts:419:15)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

I traced it in the code and noticed that the device ID for all platform accessories is hardcoded to `6781aefe-0185-4e86-8265-84c52a94b8a0`. I updated it to be `device.deviceId` instead