### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Enable debug logging for cyclic calls (e.g. polling).
 
 ### registerApplications
 
-To use installed application as input sources, a [predefined list of applications](./src/res/apps.json) will be used. This list will be checked for availability at the TV(s) and eventually be registered as input sources. Make sure to have the TV(s) turned on when starting your instance as this functionality requires your TV(s) be turned on to determine whether an application is installed or not. On startup the applications will be opened to determine if they are available. Do not use your TV until the input source is being changed back to the first one (usually Live TV).
+To use installed application as input sources, a [predefined list of applications](./src/tvApps.ts) will be used. This list will be checked for availability at the TV(s) and eventually be registered as input sources. Make sure to have the TV(s) turned on when starting your instance as this functionality requires your TV(s) be turned on to determine whether an application is installed or not. On startup the applications will be opened to determine if they are available. Do not use your TV until the input source is being changed back to the first one (usually Live TV).
 
 > [!NOTE]
 > Not implemented for SoundBars.


### PR DESCRIPTION
Corrects the link for the list of applications to point to - https://github.com/o-lukas/homebridge-smartthings-tv/blob/main/src/tvApps.ts